### PR TITLE
Adding chests

### DIFF
--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/BrewTutor.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/BrewTutor.java
@@ -3,8 +3,13 @@ package me.bethanyaryan.brewtutor;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.Chest;
+import org.bukkit.block.Sign;
 import org.bukkit.block.data.type.Leaves;
+import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -27,10 +32,6 @@ public final class BrewTutor extends JavaPlugin implements Listener {
     public final ArrayList<Player> PlayersInTutor = new ArrayList<Player>();
     public final ArrayList<StudentModel> SavedTutorData = new ArrayList<StudentModel>();
     public ArrayList<StudentModel> CurrentlyInTutorData = new ArrayList<StudentModel>();
-    public ArrayList<Task> tutorTasks = new ArrayList<Task>();
-
-    public Location brewingStandLocation;
-    public List<String> taskPrompts = Arrays.asList("Make an Awkward Potion","Click a brewing stand");
     public DecisionModel decisionModel;
     public Plugin plugin;
     @Override
@@ -41,7 +42,6 @@ public final class BrewTutor extends JavaPlugin implements Listener {
         this.plugin = this;
         this.decisionModel = new DecisionModel(this);
         this.decisionModel.run();
-
     }
 
     //Toggles the brew tutor based on if the player is in the tutor or not already
@@ -62,7 +62,6 @@ public final class BrewTutor extends JavaPlugin implements Listener {
     }
     public void start(Player player) {
         // if player has used the tutor before, grab their student model state from usedTutor list
-        createBrewingStand(player);
         boolean containsPlayer = false;
         StudentModel model = null;
 
@@ -80,47 +79,22 @@ public final class BrewTutor extends JavaPlugin implements Listener {
         }
 
         CurrentlyInTutorData.add(model);
+        model.createStartItems();
     }
     public void end(Player player){
-        deleteBrewingStand(brewingStandLocation);
         for (StudentModel sm : CurrentlyInTutorData) {
             if (sm.getPlayer() == player ){
                 CurrentlyInTutorData.remove(sm);
+                sm.deleteStartItems();
                 break;
             }
         }
     }
-    public void createBrewingStand(Player player) {
-        Location playerLocation = player.getLocation();
-        int platformZ = playerLocation.getBlockZ() + 1;
-        Location platformLocation = new Location(playerLocation.getWorld(), playerLocation.getBlockX(), playerLocation.getBlockY(), platformZ);
 
-
-        // Calculate the location of the block in front of the player based on their facing direction
-        BlockFace facingDirection = player.getFacing();
-        Location brewingStandLocation = platformLocation.getBlock().getRelative(facingDirection).getLocation();
-
-        // Spawn a brewing stand at the location in front of the player
-        brewingStandLocation.getBlock().setType(Material.BREWING_STAND);
-        //TODO: spawn pumpkin? or some villager to send prompt from?
-        this.brewingStandLocation = brewingStandLocation;
-    }
-    private void deleteBrewingStand(Location brewingStandLocation) {
-        brewingStandLocation.getBlock().setType(Material.AIR);
-    } //TODO: make it so the brewing stand is associated with the student model
-
-    @EventHandler
-    public void cancelBlockBreak(BlockBreakEvent event) {
-        //stops user from picking up block and walking away with it lol
-        if (event.getBlock().getType() == Material.BREWING_STAND) {
-            event.setCancelled(true);
-        }
-    }
     @EventHandler
     public void onPlayerInteract(PlayerInteractEvent event) {
         // Check if the clicked block is a brewing stand
         if (event.getClickedBlock() != null && event.getClickedBlock().getType() == Material.BREWING_STAND) {
-
             // The player clicked on a brewing stand
             Player player = event.getPlayer();
             player.sendMessage(ChatColor.GREEN + "You clicked on a brewing stand!");

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/BrewTutor.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/BrewTutor.java
@@ -36,6 +36,7 @@ public final class BrewTutor extends JavaPlugin implements Listener {
     public Plugin plugin;
     @Override
     public void onEnable() {
+        new CommandBrewTutor();
         System.out.println("[BrewTutor] has been enabled!");
         Objects.requireNonNull(this.getCommand("BrewTutor")).setExecutor(new CommandBrewTutor());
         getServer().getPluginManager().registerEvents(this, this);
@@ -78,12 +79,15 @@ public final class BrewTutor extends JavaPlugin implements Listener {
             SavedTutorData.add(model);
         }
 
+        //add to list, create start items, start prompt
         CurrentlyInTutorData.add(model);
         model.createStartItems();
+        model.waitingForPrompt = true;
     }
     public void end(Player player){
         for (StudentModel sm : CurrentlyInTutorData) {
             if (sm.getPlayer() == player ){
+                //boop them from list, remove spawned items
                 CurrentlyInTutorData.remove(sm);
                 sm.deleteStartItems();
                 break;
@@ -99,12 +103,12 @@ public final class BrewTutor extends JavaPlugin implements Listener {
             Player player = event.getPlayer();
             player.sendMessage(ChatColor.GREEN + "You clicked on a brewing stand!");
 
-            Task task = new Task(player, this.plugin);
-            ItemStack stack = new ItemStack(Material.POTION);
-            PotionMeta thing = (PotionMeta)stack.getItemMeta();
-            thing.setBasePotionType(PotionType.AWKWARD);
-            stack.setItemMeta(thing);
-            task.checkConditionMet(stack);
+//            Task task = new Task(player, this.plugin);
+//            ItemStack stack = new ItemStack(Material.POTION);
+//            PotionMeta thing = (PotionMeta)stack.getItemMeta();
+//            thing.setBasePotionType(PotionType.AWKWARD);
+//            stack.setItemMeta(thing);
+//            task.checkConditionMet(stack);
         }
     }
 

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/CommandBrewTutor.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/CommandBrewTutor.java
@@ -1,6 +1,7 @@
 package me.bethanyaryan.brewtutor;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -11,9 +12,10 @@ public class CommandBrewTutor implements CommandExecutor {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         Player player = (Player) sender;
         BrewTutor plugin = (BrewTutor) Bukkit.getPluginManager().getPlugin("BrewTutor");
-        if(label.equalsIgnoreCase("BrewTutor")) {
+        if(command.getName().equalsIgnoreCase("BrewTutor")) {
             plugin.toggleBrewTutor(player);
         }
+
         //TODO: add hint command
         return true;
     }

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/Constants.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/Constants.java
@@ -37,5 +37,5 @@ public class Constants {
                             KNOWLEDGE_COMPONENTS.REGEN
                     }
             )
-    };
+    };//TODO: maybe add a "final" task that is just "woot woot you finished"?
 }

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/Constants.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/Constants.java
@@ -1,5 +1,7 @@
 package me.bethanyaryan.brewtutor;
 
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionType;
 
 public class Constants {
@@ -7,6 +9,14 @@ public class Constants {
         // Restrict instantiation
     }
 
+    public static final ItemStack[] MATERIALS = new ItemStack[] {
+            new ItemStack(Material.NETHER_WART, 1),
+            new ItemStack(Material.WATER, 1),
+            new ItemStack(Material.GHAST_TEAR, 1),
+            new ItemStack(Material.STRING, 1),
+            new ItemStack(Material.INK_SAC, 1),
+            new ItemStack(Material.APPLE, 1)
+    };
     // List of all the tasks that can be provided to a user in order of difficulty
     public static final Task[] TASKS = new Task[] {
             new Task(

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/Constants.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/Constants.java
@@ -11,7 +11,7 @@ public class Constants {
 
     public static final ItemStack[] MATERIALS = new ItemStack[] {
             new ItemStack(Material.NETHER_WART, 1),
-            new ItemStack(Material.WATER, 1),
+            new ItemStack(Material.GLASS_BOTTLE, 1),
             new ItemStack(Material.GHAST_TEAR, 1),
             new ItemStack(Material.STRING, 1),
             new ItemStack(Material.INK_SAC, 1),

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/DecisionModel.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/DecisionModel.java
@@ -1,9 +1,6 @@
 package me.bethanyaryan.brewtutor;
 
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Color;
-import org.bukkit.Location;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.entity.Item;
@@ -54,12 +51,15 @@ public class DecisionModel {
                     }
                 }
 
-                //refill chests with materials
+                //refill chests with materials and brewing stand fuel
                 Chest materialChest = sm.materialChest;
                 ItemStack[] materials = getNonNullItems(materialChest.getInventory().getContents());
                 if (materials.length < MATERIALS.length){
                     sm.refillMaterials();
                 }
+
+                sm.brewingStand.getInventory().setFuel(new ItemStack(Material.BLAZE_POWDER, 1));
+                //TODO: add this to student model? ^
 
             }
         }, 20L * 10L /*<-- the initial delay */, 20L * 5L /*<-- the interval */); //TODO: adjust this time interval

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/DecisionModel.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/DecisionModel.java
@@ -38,28 +38,35 @@ public class DecisionModel {
                 Location chestLocation = sm.submissionChestLocation;
 
                 Chest chest = (Chest) player.getWorld().getBlockAt(chestLocation).getState();
-                ItemStack[] content = chest.getInventory().getContents();
+                ItemStack[] submissionChestItems = chest.getInventory().getContents();
+                ItemStack[] submission = getNonNullItems(submissionChestItems);
 
-
-                if (chest.getInventory().getContents().length > 0){
-//                    if (chest.getInventory().getContents().length > 1){
-//                        player.sendMessage(ChatColor.DARK_PURPLE + "Witch: You have too many items in the submission chest. 1 submission at a time please.");
-//                    }else{
-                    ItemStack[] submission = chest.getInventory().getContents();
-                    for (ItemStack item : submission){
-//                        player.sendMessage(ChatColor.DARK_PURPLE + "Witch: you submitted a " + item.toString());
-//                        sm.submitTask(item); //should only be 1
-                        System.out.println(item);
-//                        break;
+                if (submission.length > 0){
+                    if (submission.length > 1){
+                        player.sendMessage(ChatColor.DARK_PURPLE + "Witch: You have too many items in the submission chest. 1 submission at a time please.");
+                    }else{
+                        for (ItemStack item : submission){
+                            player.sendMessage(ChatColor.DARK_PURPLE + "Witch: you submitted a " + item.toString());
+                            sm.submitTask(item);
+                            chest.getInventory().remove(item);
+                            break; //should only be 1
+                        }
                     }
-//                    }
-
                 }
-                //if student submitted a response to their task, grade submission
 
                 //TODO: decision making logic goes here. Update student knowledge, iterate to next prompt, ect
             }
         }, 20L * 10L /*<-- the initial delay */, 20L * 5L /*<-- the interval */); //TODO: adjust this time interval
+    }
+
+    private ItemStack[] getNonNullItems(ItemStack[] items) {
+        ArrayList<ItemStack> nonNullItems = new ArrayList<>();
+        for (ItemStack item : items) {
+            if (item != null) {
+                nonNullItems.add(item);
+            }
+        }
+        return nonNullItems.toArray(new ItemStack[0]);
     }
 
     public void stop(){

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/DecisionModel.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/DecisionModel.java
@@ -3,9 +3,16 @@ package me.bethanyaryan.brewtutor;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.Chest;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitScheduler;
+
+import java.util.ArrayList;
 
 
 public class DecisionModel {
@@ -27,6 +34,30 @@ public class DecisionModel {
                     player.sendMessage(ChatColor.DARK_PURPLE + "Witch: " + sm.getQuestion());
                     sm.waitingForPrompt = false;
                 }
+
+                Location chestLocation = sm.submissionChestLocation;
+
+                Chest chest = (Chest) player.getWorld().getBlockAt(chestLocation).getState();
+                ItemStack[] content = chest.getInventory().getContents();
+                long count = chest.getInventory().getContents().stream()
+                        .filter(item -> item != null)
+                        .count();
+
+                if (chest.getInventory().getContents().length > 0){
+//                    if (chest.getInventory().getContents().length > 1){
+//                        player.sendMessage(ChatColor.DARK_PURPLE + "Witch: You have too many items in the submission chest. 1 submission at a time please.");
+//                    }else{
+                    ItemStack[] submission = chest.getInventory().getContents();
+                    for (ItemStack item : submission){
+//                        player.sendMessage(ChatColor.DARK_PURPLE + "Witch: you submitted a " + item.toString());
+//                        sm.submitTask(item); //should only be 1
+                        System.out.println(item);
+//                        break;
+                    }
+//                    }
+
+                }
+                //if student submitted a response to their task, grade submission
 
                 //TODO: decision making logic goes here. Update student knowledge, iterate to next prompt, ect
             }

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/KnowledgeComponents.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/KnowledgeComponents.java
@@ -30,6 +30,7 @@ public class KnowledgeComponents {
         }
 
         this.masteryLevel = probL1 + (1 - probL1) * acquisition;
+        System.out.println(this.masteryLevel);
     }
 
     @Override

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/StudentModel.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/StudentModel.java
@@ -1,6 +1,20 @@
 package me.bethanyaryan.brewtutor;
 
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.Chest;
+import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -9,13 +23,18 @@ import java.util.List;
 
 import static me.bethanyaryan.brewtutor.Constants.TASKS;
 
-public class StudentModel {
+public class StudentModel implements Listener {
     private final Player player;
+    ArrayList<Location> itemLocations = new ArrayList<Location>();
+    public Location submissionChestLocation;
+
     private int questionId;
     private int hintCount;
     private List<KnowledgeComponents> knowledgeComponents = new ArrayList<KnowledgeComponents>();
     private Task currentTask;
     public boolean waitingForPrompt;
+
+    public boolean submittedTask;
 
     public StudentModel(Player player) {
         super();
@@ -68,6 +87,50 @@ public class StudentModel {
         this.hintCount = 0;
     }
 
+    public void createStartItems(){
+        Block brewingStandBlock = this.player.getLocation().getBlock().getRelative(BlockFace.SOUTH);
+        Block materialChestBlock = brewingStandBlock.getLocation().getBlock().getRelative(BlockFace.WEST);
+        Block submissionChestBlock = brewingStandBlock.getLocation().getBlock().getRelative(BlockFace.EAST);
+
+        brewingStandBlock.setType(Material.BREWING_STAND);
+        materialChestBlock.setType(Material.CHEST);
+        submissionChestBlock.setType(Material.CHEST);
+
+        // Fill the chest with a stack of Netherwart and other things
+        //TODO: fill with other things
+        Chest materialChest = (Chest) materialChestBlock.getState();
+        ItemStack netherwartStack = new ItemStack(Material.NETHER_WART, 64);
+        materialChest.getInventory().addItem(netherwartStack);
+
+        // put a sign on the chests
+        Block materialSignBlock = materialChestBlock.getRelative(BlockFace.SOUTH);
+        materialSignBlock.setType(Material.OAK_SIGN);
+        Sign materialSign = (Sign) materialSignBlock.getState();
+        materialSign.getSide(Side.BACK).setLine(0, "Materials");
+        materialSign.update();
+
+        Block submissionSignBlock = submissionChestBlock.getRelative(BlockFace.SOUTH);
+        submissionSignBlock.setType(Material.OAK_SIGN);
+        Sign submissionSign = (Sign) submissionSignBlock.getState();
+        submissionSign.getSide(Side.BACK).setLine(0, "Submissions");
+        submissionSign.update();
+
+        //add signs first, so they'll be the first to be deleted
+        this.itemLocations.add((materialSign.getLocation()));
+        this.itemLocations.add((submissionSign.getLocation()));
+        this.itemLocations.add(brewingStandBlock.getLocation());
+        this.itemLocations.add((materialChestBlock.getLocation()));
+        this.itemLocations.add((submissionChestBlock.getLocation()));
+
+        this.submissionChestLocation = submissionChestBlock.getLocation();
+    }
+
+    public void deleteStartItems(){
+        for (Location location : this.itemLocations) {
+            location.getBlock().setType(Material.AIR);
+        }
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this.getClass() != obj.getClass())
@@ -80,5 +143,12 @@ public class StudentModel {
     public String toString(){
         return this.player.getDisplayName();
     }
+    @EventHandler
+    public void cancelBlockBreak(BlockBreakEvent event) {
+        if (this.itemLocations.contains(event.getBlock().getLocation())) {
+            event.setCancelled(true);
+        }
+    }
+
 }
 

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/StudentModel.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/StudentModel.java
@@ -3,10 +3,7 @@ package me.bethanyaryan.brewtutor;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-import org.bukkit.block.Chest;
-import org.bukkit.block.Sign;
+import org.bukkit.block.*;
 import org.bukkit.block.sign.Side;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -23,8 +20,8 @@ public class StudentModel implements Listener {
     private final Player player;
     ArrayList<Location> itemLocations = new ArrayList<Location>();
     public Chest submissionChest;
-
     public Chest materialChest;
+    public BrewingStand brewingStand;
     private int questionId;
     private int hintCount;
     private final List<KnowledgeComponents> knowledgeComponents = new ArrayList<>();
@@ -100,13 +97,16 @@ public class StudentModel implements Listener {
         Block brewingStandBlock = this.player.getLocation().getBlock().getRelative(BlockFace.SOUTH);
         Block materialChestBlock = brewingStandBlock.getLocation().getBlock().getRelative(BlockFace.WEST);
         Block submissionChestBlock = brewingStandBlock.getLocation().getBlock().getRelative(BlockFace.EAST);
+        Block waterCauldronBlock = materialChestBlock.getLocation().getBlock().getRelative(BlockFace.WEST);
 
         brewingStandBlock.setType(Material.BREWING_STAND);
         materialChestBlock.setType(Material.CHEST);
         submissionChestBlock.setType(Material.CHEST);
+        waterCauldronBlock.setType(Material.WATER_CAULDRON);
 
         Chest materialChest = (Chest) materialChestBlock.getState();
         Chest submissionChest = (Chest) submissionChestBlock.getState();
+        BrewingStand brewingStand = (BrewingStand) brewingStandBlock.getState();
 
         // put a sign on the chests
         Block materialSignBlock = materialChestBlock.getRelative(BlockFace.SOUTH);
@@ -122,14 +122,16 @@ public class StudentModel implements Listener {
         submissionSign.update();
 
         //add signs first, so they'll be the first to be deleted
-        this.itemLocations.add((materialSign.getLocation()));
-        this.itemLocations.add((submissionSign.getLocation()));
+        this.itemLocations.add(materialSign.getLocation());
+        this.itemLocations.add(submissionSign.getLocation());
         this.itemLocations.add(brewingStandBlock.getLocation());
-        this.itemLocations.add((materialChestBlock.getLocation()));
-        this.itemLocations.add((submissionChestBlock.getLocation()));
+        this.itemLocations.add(materialChestBlock.getLocation());
+        this.itemLocations.add(submissionChestBlock.getLocation());
+        this.itemLocations.add(waterCauldronBlock.getLocation());
 
         this.submissionChest = submissionChest;
         this.materialChest = materialChest;
+        this.brewingStand = brewingStand;
         refillMaterials();
     }
 
@@ -143,6 +145,7 @@ public class StudentModel implements Listener {
     private void determineNextQuestion() {
         if (this.questionId == TASKS.length-1) {
             this.player.sendMessage(ChatColor.GREEN + "WOW YOU LEARNED IT ALL CONGRATULATIONS!!!");
+            //TODO: end tutor
             return;
         }
 

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/StudentModel.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/StudentModel.java
@@ -65,6 +65,8 @@ public class StudentModel implements Listener {
         // If the player completed the task successfully, calculate the next task to give them
         if (evidence) {
             determineNextQuestion();
+        }else{
+            player.sendMessage(ChatColor.RED + "WRONG. Please try again.");
         }
     }
     public int getQuestionId() {
@@ -138,6 +140,7 @@ public class StudentModel implements Listener {
             return;
         }
 
+        this.waitingForPrompt = true;
         for (int i=this.questionId; i < TASKS.length-1; i++) {
             Task tempTask = new Task(TASKS[i], this.player, null);
 

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/StudentModel.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/StudentModel.java
@@ -16,13 +16,15 @@ import org.bukkit.inventory.ItemStack;
 import java.util.ArrayList;
 import java.util.List;
 
+import static me.bethanyaryan.brewtutor.Constants.MATERIALS;
 import static me.bethanyaryan.brewtutor.Constants.TASKS;
 
 public class StudentModel implements Listener {
     private final Player player;
     ArrayList<Location> itemLocations = new ArrayList<Location>();
-    public Location submissionChestLocation;
+    public Chest submissionChest;
 
+    public Chest materialChest;
     private int questionId;
     private int hintCount;
     private final List<KnowledgeComponents> knowledgeComponents = new ArrayList<>();
@@ -40,7 +42,7 @@ public class StudentModel implements Listener {
 
     }
     public Player getPlayer(){
-        System.out.println("Called get player with student model");
+//        System.out.println("Called get player with student model");
         return this.player;
     }
     public String getQuestion(){
@@ -65,8 +67,6 @@ public class StudentModel implements Listener {
         // If the player completed the task successfully, calculate the next task to give them
         if (evidence) {
             determineNextQuestion();
-        }else{
-            player.sendMessage(ChatColor.RED + "WRONG. Please try again.");
         }
     }
     public int getQuestionId() {
@@ -89,6 +89,13 @@ public class StudentModel implements Listener {
         this.hintCount = 0;
     }
 
+    public void refillMaterials() {
+        this.materialChest.getInventory().clear();
+        for (ItemStack material : MATERIALS){
+            this.materialChest.getInventory().addItem(material);
+        }
+    }
+
     public void createStartItems(){
         Block brewingStandBlock = this.player.getLocation().getBlock().getRelative(BlockFace.SOUTH);
         Block materialChestBlock = brewingStandBlock.getLocation().getBlock().getRelative(BlockFace.WEST);
@@ -98,11 +105,8 @@ public class StudentModel implements Listener {
         materialChestBlock.setType(Material.CHEST);
         submissionChestBlock.setType(Material.CHEST);
 
-        // Fill the chest with a stack of Netherwart and other things
-        //TODO: fill with other things
         Chest materialChest = (Chest) materialChestBlock.getState();
-        ItemStack netherwartStack = new ItemStack(Material.NETHER_WART, 64);
-        materialChest.getInventory().addItem(netherwartStack);
+        Chest submissionChest = (Chest) submissionChestBlock.getState();
 
         // put a sign on the chests
         Block materialSignBlock = materialChestBlock.getRelative(BlockFace.SOUTH);
@@ -124,7 +128,9 @@ public class StudentModel implements Listener {
         this.itemLocations.add((materialChestBlock.getLocation()));
         this.itemLocations.add((submissionChestBlock.getLocation()));
 
-        this.submissionChestLocation = submissionChestBlock.getLocation();
+        this.submissionChest = submissionChest;
+        this.materialChest = materialChest;
+        refillMaterials();
     }
 
     public void deleteStartItems() {

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/StudentModel.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/StudentModel.java
@@ -141,7 +141,7 @@ public class StudentModel implements Listener {
         }
 
         this.waitingForPrompt = true;
-        for (int i=this.questionId; i < TASKS.length-1; i++) {
+        for (int i=this.questionId; i <= TASKS.length-1; i++) {
             Task tempTask = new Task(TASKS[i], this.player, null);
 
             // Check if knowledge components that are needed are mastered

--- a/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/Task.java
+++ b/BrewTutor/src/main/java/me/bethanyaryan/brewtutor/Task.java
@@ -75,6 +75,7 @@ public class Task {
 
     // @Parameter submission : The potion the player created
     public boolean checkConditionMet(ItemStack submission) {
+        //TODO: doesn't catch non potion type items for some reason
         if (!(submission.getType() == Material.POTION)) { return false; }
 
         PotionMeta potion = (PotionMeta)submission.getItemMeta();
@@ -86,7 +87,6 @@ public class Task {
             return true;
         } else {
             this.player.sendMessage(ChatColor.RED + "That's Not Quite Right. Try Again! Remember you can type /hint to get some help!");
-            // TODO: Maybe empty the chest to prevent this being called multiple times?
         }
 
         return false;

--- a/BrewTutor/src/main/resources/plugin.yml
+++ b/BrewTutor/src/main/resources/plugin.yml
@@ -9,3 +9,6 @@ commands:
   BrewTutor:
     description: Toggles the BrewTutor plugin
     usage: /brewtutor
+  hint:
+    description: gives the user the next hint
+    usage: /hint


### PR DESCRIPTION
Spawns in:
- Submission chest that takes 1 item at a time for submission
- Brewing stand with infinite blazing powder 
- Materials chest filled with starter ingredients.
        - MATERIALS in constants lists the items we want to fill the chest with each time. Update this list to change what is spawned in.
- Water cauldron
       - Figured it'd be a fun touch. We can remove it though and just place a potion of type water into the materials chest instead if we like that better. Currently has just empty glass bottles spawn into the materials chest to fill.

Material chest refills whenever the count of the items in the chest is less than the length of the MATERIALS constant list. 
Brewing stand blaze powder refills during this time as well. If they take an item out of the chest, it just makes sure there is a blaze powder ready to go in the brewing stand.

 